### PR TITLE
t2.micro => t2.medium so container has enough memory to start

### DIFF
--- a/.delta
+++ b/.delta
@@ -1,4 +1,6 @@
 builds:
   - root:
+      instance.type: t2.medium
+      memory: 3500
       port.container: 9000
       port.host: 6041


### PR DESCRIPTION
```
...
...
Java HotSpot(TM) 64-Bit Server VM warning: INFO: os::commit_memory(0x00000000e2d50000, 489357312, 0) failed; error='Cannot allocate memory' (errno=12)
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 489357312 bytes for committing reserved memory.
# An error report file with more information is saved as:
# /opt/play/api/target/universal/stage/hs_err_pid16.log
...
...
```